### PR TITLE
Fixed error when the config folder does not exist

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@ echo "This will replace the current terminator config file"
 function copy_config() {
     echo "Applying Dracula theme..."
     echo "Copying config file to ~/.config/terminator"
+    mkdir -p $config_dir
     cp -rf  $current_dir/config/config $config_dir
     echo "terminator config updated!"
     echo "If you want to edit config, edit ~/.config/terminator/config file"


### PR DESCRIPTION
Fixes an error when the ~/.config/terminator folder does not exist.